### PR TITLE
[ Fix ] Header Footer Layout

### DIFF
--- a/src/components/server/Footer/Footer.tsx
+++ b/src/components/server/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { FooterInfo, FooterNavigator } from './components';
 
 const Footer = () => {
   return (
-    <footer className='w-full h-[20rem] flex justify-center shadow-shadow_500 absolute bottom-0'>
+    <footer className='w-full h-[20rem] flex justify-center shadow-shadow_500'>
       <div className='w-full max-w-[100rem] min-w-[27rem] h-full flex flex-col justify-center gap-[1rem] text-nowrap'>
         <FooterNavigator />
         <Divider />

--- a/src/components/server/Header/components/HeaderNoneResponsive/HeaderNoneResponsive.tsx
+++ b/src/components/server/Header/components/HeaderNoneResponsive/HeaderNoneResponsive.tsx
@@ -4,7 +4,7 @@ import HeaderUserInfo from '../HeaderUserInfo/HeaderUserInfo';
 
 const HeaderNoneResponsive = () => {
   return (
-    <header className='w-full h-[8.8rem] hidden items-center justify-between shadow-shadow_500 header_min:flex'>
+    <header className='w-full h-[9rem] hidden items-center justify-between shadow-shadow_500 header_min:flex'>
       <HeaderLogo />
       <HeaderNavbar />
       <HeaderUserInfo />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,7 +7,8 @@
 
   --text-size: 3rem;
 
-  --test: 900;
+  --header-height: 9rem;
+  --footer-height: 20rem;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -37,6 +38,20 @@
     height: 100%;
 
     position: relative;
+    overflow: scroll;
+
+    ::-webkit-scrollbar {
+      display: none;
+    }
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+
+  #fit-wrap {
+    width: 100%;
+    height: calc(100% - var(--header-height) - var(--footer-height));
+    min-height: calc(100% - var(--header-height) - var(--footer-height));
+
     overflow: scroll;
 
     ::-webkit-scrollbar {


### PR DESCRIPTION
## 📝 설명

- #82 

close #82 


## ✅ PR 유형

- [x] 새로운 기능 추가


# 해당 페이지의 어떠한 요소도 `Height` 값을 상속받지 않을때

기본 `default` 값입니다. 별도의 스타일을 지정할 필요없이 사용하시면 됩니다.

# 해당 페이지가 부모의 Height 값을 상속받아야하는경우 ( `100%` - `HeaderHeight` - `FooterHeight` )
 
해당 페이지의 경우 별도의 layout을 생성하고 작업을 해야합니다.
![code](https://github.com/love-invitation/PInk_Cotton_FE/assets/127748428/f17e42d9-29b0-4a7e-8d5a-5c97c43b5faf)

위 이미지와 같이 #fit-wrap id값을 상위에 지정해주면 자동적으로 footer는 하단, header 는 상단에 고정됩니다.
이후 내부 요소는 `100%` - `HeaderHeight` - `FooterHeight` 값을 상속 받을 수 있습니다.

추가로 fit-wrap은 overflow-scroll이 적용되어 내부에 요소가 많아져도 스크롤로 통제됩니다.
