### PR TITLE
[ Feature ] Wedding Place Input 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "lodash": "^4.17.21",
         "next": "14.1.4",
         "react": "^18",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18",
         "react-hook-form": "^7.51.3",
         "react-kakao-maps-sdk": "^1.1.26",
@@ -16703,6 +16704,14 @@
       },
       "peerDependencies": {
         "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
+      }
+    },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-docgen": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lodash": "^4.17.21",
     "next": "14.1.4",
     "react": "^18",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18",
     "react-hook-form": "^7.51.3",
     "react-kakao-maps-sdk": "^1.1.26",

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/InvitationCover/InvitationCover.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/InvitationCover/InvitationCover.tsx
@@ -1,5 +1,5 @@
 const InvitationCover = () => {
-  return <section>표지 사진</section>;
+  return <section className='min-w-[20rem] w-[40%] border-2'>표지 사진</section>;
 };
 
 export default InvitationCover;

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/ProduceFormInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/ProduceFormInput.tsx
@@ -1,8 +1,9 @@
-import { ArticleInput, CoverInput, GroomBrideInput } from './_components';
+import { ArticleInput, CoverInput, GroomBrideInput, WeddingPlageInput } from './_components';
 
 const ProduceFormInput = () => {
   return (
     <section className='flex flex-col gap-[2rem]'>
+      <WeddingPlageInput />
       <CoverInput />
       <ArticleInput />
       <GroomBrideInput type='groom' />

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/ProduceFormInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/ProduceFormInput.tsx
@@ -3,11 +3,11 @@ import { ArticleInput, CoverInput, GroomBrideInput, WeddingPlageInput } from './
 const ProduceFormInput = () => {
   return (
     <section className='w-[60%] min-w-[30rem] flex flex-col gap-[2rem] mobile:w-full'>
-      <WeddingPlageInput />
       <CoverInput />
       <ArticleInput />
       <GroomBrideInput type='groom' />
       <GroomBrideInput type='bride' />
+      <WeddingPlageInput />
     </section>
   );
 };

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/ProduceFormInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/ProduceFormInput.tsx
@@ -2,7 +2,7 @@ import { ArticleInput, CoverInput, GroomBrideInput, WeddingPlageInput } from './
 
 const ProduceFormInput = () => {
   return (
-    <section className='flex flex-col gap-[2rem]'>
+    <section className='w-[60%] min-w-[30rem] flex flex-col gap-[2rem] mobile:w-full'>
       <WeddingPlageInput />
       <CoverInput />
       <ArticleInput />

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/CoverInput/CoverInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/CoverInput/CoverInput.tsx
@@ -34,12 +34,10 @@ const CoverInput = () => {
             <div className='flex gap-[1.7rem]'>
               <Input.Input
                 name='groom.name'
-                value={watch('groom.name')}
                 placeholder='이름'
               />
               <Input.Input
                 name='bride.name'
-                value={watch('bride.name')}
                 placeholder='이름'
               />
             </div>

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/GroomBrideInput/GroomBrideInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/GroomBrideInput/GroomBrideInput.tsx
@@ -31,15 +31,6 @@ const GroomBrideInput = ({ type }: GroomBrideInputProps) => {
       defaultToggleValue
     >
       <Input className='w-full flex flex-col py-[2rem] gap-[2rem]'>
-        {/* <div className={commonStyle.inputContainer}>
-          <Input.Label className={commonStyle.inputLabel}>{typeName}</Input.Label>
-          <Input.Input
-            className={commonStyle.input}
-            name={`${type}.name`}
-            placeholder='이름'
-          />
-        </div> */}
-
         <div className={commonStyle.inputContainer}>
           <Input.Label className={commonStyle.inputLabel}>{`${typeName}측 아버님`}</Input.Label>
           <Input.Input

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
@@ -34,11 +34,12 @@ const WeddingPlageInput = () => {
 
         <div className='w-full flex flex-col gap-[1rem]'>
           <Input.Label>주소</Input.Label>
-          <input
+
+          <Input.Input
+            name='place.address'
             readOnly
             value={address}
             placeholder='주소'
-            className='focus:border-pink_300 focus:border-2 h-[4.8rem] w-full rounded-radius10 border border-solid border-placeholder_100 px-[2.4rem] py-[1.6rem] text-[1.6rem] font-medium bg-white_100'
             onClick={handleClickAddress}
           />
         </div>

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { Accordion, Input, PinkMap } from '@/components/client';
+import { Accordion, AlertModal, Input, PinkMap } from '@/components/client';
+import { useModal } from '@/hooks';
 
 import { useGetAddress } from './hooks';
 
 const WeddingPlageInput = () => {
-  const { center, handleClickAddress, address } = useGetAddress();
+  const { isShowModal, closeModal, showModal } = useModal();
+  const { center, handleClickAddress, address, alertMessage } = useGetAddress({ showModal });
 
   return (
     <Accordion
@@ -49,6 +51,12 @@ const WeddingPlageInput = () => {
           />
         )}
       </Input>
+
+      <AlertModal
+        message={alertMessage}
+        isShow={isShowModal}
+        onClose={closeModal}
+      />
     </Accordion>
   );
 };

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Accordion, Input } from '@/components/client';
+
+const WeddingPlageInput = () => {
+  return (
+    <Accordion
+      type='edit'
+      buttonTitle='예식 장소'
+      defaultToggleValue
+    >
+      <Input className=''>input</Input>
+    </Accordion>
+  );
+};
+
+export default WeddingPlageInput;

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/WeddingPlageInput.tsx
@@ -1,15 +1,54 @@
 'use client';
 
-import { Accordion, Input } from '@/components/client';
+import { Accordion, Input, PinkMap } from '@/components/client';
+
+import { useGetAddress } from './hooks';
 
 const WeddingPlageInput = () => {
+  const { center, handleClickAddress, address } = useGetAddress();
+
   return (
     <Accordion
       type='edit'
       buttonTitle='예식 장소'
       defaultToggleValue
     >
-      <Input className=''>input</Input>
+      <Input className='w-full flex-col gap-[2rem] py-[2rem]'>
+        <div className='w-full flex flex-col gap-[1rem]'>
+          <Input.Label>예식장 이름</Input.Label>
+          <Input.Input
+            name='place.name'
+            placeholder='PINK COTTON 웨딩 홀'
+          />
+        </div>
+
+        <div className='w-full flex flex-col gap-[1rem]'>
+          <Input.Label>층과 홀</Input.Label>
+          <Input.Input
+            name='place.detail'
+            placeholder='7F, 이스트홀'
+          />
+        </div>
+
+        <div className='w-full flex flex-col gap-[1rem]'>
+          <Input.Label>주소</Input.Label>
+          <input
+            readOnly
+            value={address}
+            placeholder='주소'
+            className='focus:border-pink_300 focus:border-2 h-[4.8rem] w-full rounded-radius10 border border-solid border-placeholder_100 px-[2.4rem] py-[1.6rem] text-[1.6rem] font-medium bg-white_100'
+            onClick={handleClickAddress}
+          />
+        </div>
+
+        {center && (
+          <PinkMap
+            center={center}
+            width='100%'
+            height='25rem'
+          />
+        )}
+      </Input>
     </Accordion>
   );
 };

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/index.ts
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useGetAddress } from './useGetAddress/useGetAddress';

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.ts
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { Address, useDaumPostcodePopup } from 'react-daum-postcode';
+import { useFormContext } from 'react-hook-form';
+
+import { GeoPosition } from '@/types/originType';
+
+const useGetAddress = () => {
+  const [center, setCenter] = useState<GeoPosition | null>(null);
+  const [geocoder, setGeocoder] = useState<kakao.maps.services.Geocoder | null>(null);
+  const { setValue, watch } = useFormContext();
+
+  useEffect(() => {
+    kakao.maps.load(() => {
+      const geo = new kakao.maps.services.Geocoder();
+      setGeocoder(geo);
+    });
+  }, []);
+
+  const open = useDaumPostcodePopup();
+
+  const handleClickAddress = () => {
+    open({
+      onComplete: (data: Address) => {
+        setValue('place.address', data.roadAddress);
+        if (!geocoder) {
+          // 경고 처리 하기
+          return;
+        }
+
+        geocoder.addressSearch(data.address, (result, state) => {
+          if (state === kakao.maps.services.Status.OK) {
+            setCenter({
+              lat: Number(result[0].y),
+              lng: Number(result[0].x),
+            });
+          }
+        });
+      },
+
+      onError: () => {
+        // 실패 처리 하기
+      },
+    });
+  };
+
+  return {
+    center,
+    handleClickAddress,
+    address: watch('place.address'),
+  };
+};
+
+export default useGetAddress;

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.ts
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.ts
@@ -4,9 +4,12 @@ import { useFormContext } from 'react-hook-form';
 
 import { GeoPosition } from '@/types/originType';
 
-const useGetAddress = () => {
+import { UseGetAddressProps } from './useGetAddress.type';
+
+const useGetAddress = ({ showModal }: UseGetAddressProps) => {
   const [center, setCenter] = useState<GeoPosition | null>(null);
   const [geocoder, setGeocoder] = useState<kakao.maps.services.Geocoder | null>(null);
+  const [alertMessage, setAlertMessage] = useState('');
   const { setValue, watch } = useFormContext();
 
   useEffect(() => {
@@ -23,7 +26,8 @@ const useGetAddress = () => {
       onComplete: (data: Address) => {
         setValue('place.address', data.roadAddress);
         if (!geocoder) {
-          // 경고 처리 하기
+          showModal();
+          setAlertMessage('지도를 불러오는 과정에 \n 문제가 발생하였습니다.');
           return;
         }
 
@@ -38,7 +42,8 @@ const useGetAddress = () => {
       },
 
       onError: () => {
-        // 실패 처리 하기
+        showModal();
+        setAlertMessage('주소 입력 과정에서 \n 문제가 발생하였습니다.');
       },
     });
   };
@@ -47,6 +52,7 @@ const useGetAddress = () => {
     center,
     handleClickAddress,
     address: watch('place.address'),
+    alertMessage,
   };
 };
 

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.ts
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.ts
@@ -25,6 +25,7 @@ const useGetAddress = ({ showModal }: UseGetAddressProps) => {
     open({
       onComplete: (data: Address) => {
         setValue('place.address', data.roadAddress);
+
         if (!geocoder) {
           showModal();
           setAlertMessage('지도를 불러오는 과정에 \n 문제가 발생하였습니다.');

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.type.ts
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/WeddingPlageInput/hooks/useGetAddress/useGetAddress.type.ts
@@ -1,0 +1,3 @@
+export interface UseGetAddressProps {
+  showModal: () => void;
+}

--- a/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/index.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/_components/ProduceFormInput/_components/index.tsx
@@ -1,3 +1,4 @@
 export { default as CoverInput } from './CoverInput/CoverInput';
 export { default as ArticleInput } from './ArticleInput/ArticleInput';
 export { default as GroomBrideInput } from './GroomBrideInput/GroomBrideInput';
+export { default as WeddingPlageInput } from './WeddingPlageInput/WeddingPlageInput';

--- a/src/app/(Web)/wedding/invitations/produce/[id]/page.tsx
+++ b/src/app/(Web)/wedding/invitations/produce/[id]/page.tsx
@@ -14,7 +14,7 @@ const ProducePage = () => {
     <FormProvider {...form}>
       <form
         id='calc_header_footer_height'
-        className='flex py-[4.8rem] px-[12rem] gap-[2rem] justify-center'
+        className='flex w-full py-[4.8rem] px-[10rem] tablet:px-[5rem] gap-[2rem] justify-center mobile:flex-col'
       >
         <InvitationCover />
         <ProduceFormInput />


### PR DESCRIPTION
## 📝 설명

- #111 

close #111 


## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] CSS 등 사용자 UI 디자인 변경

## 💻 작업 내용

결혼식 장소를 입력받을 수 있는 Wedding Place Input 구현 <br>

주소 Input은 클릭시 별도의 팝업이 동작하여 입력받습니다.


- 주소 입력 전
<img width="478" alt="image" src="https://github.com/love-invitation/PInk_Cotton_FE/assets/127748428/b067ccea-b02a-4db5-aa66-843ebdd8e985">

- 주소 입력 후

<img width="481" alt="image" src="https://github.com/love-invitation/PInk_Cotton_FE/assets/127748428/c288ce4c-f7f4-4382-9a79-35f234faf3c9">

### 반응형 구현

Procude 페이지의 전체적인 반응형 레이아웃 정리

1024 이상 : px 값 10rem으로 동작

600 ~ 1024 사이 : px 5rem으로 축소

600 이하 : flex - col 변경

표지 위치 : 기본 너비 40% , 최소 너비 20rem으로 지정

인풋 창 : 기본 너비 60% 최소 너비 30rem으로 지정

<!-- PR 본문을 입력하세요. -->


## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
