### PR TITLE
[ Feature ] 첩첩장 조회 페이지 API 연결

### DIFF
--- a/src/app/(Product)/wedding/invite/[id]/page.tsx
+++ b/src/app/(Product)/wedding/invite/[id]/page.tsx
@@ -2,7 +2,7 @@ import { QUERY_OPTIONS, getQueryClient } from '@/constants';
 
 const InvitePage = async () => {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION_PRODUCE('592999830142739431'));
+  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION('592999830142739431'));
 
   // const data = queryClient.getQueryData(QUERY_KEYS.INVITATION_PRODUCE('592999830142739431'));
 

--- a/src/app/(Product)/wedding/invite/[id]/page.tsx
+++ b/src/app/(Product)/wedding/invite/[id]/page.tsx
@@ -1,4 +1,13 @@
-const InvitePage = () => {
+import { QUERY_OPTIONS, getQueryClient } from '@/constants';
+
+const InvitePage = async () => {
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION_PRODUCE('592999830142739431'));
+
+  // const data = queryClient.getQueryData(QUERY_KEYS.INVITATION_PRODUCE('592999830142739431'));
+
+  // console.log(data);
+
   return <div>invite Page</div>;
 };
 

--- a/src/app/(Product)/wedding/invite/[id]/page.tsx
+++ b/src/app/(Product)/wedding/invite/[id]/page.tsx
@@ -1,14 +1,24 @@
-import { QUERY_OPTIONS, getQueryClient } from '@/constants';
+import { QUERY_KEYS, QUERY_OPTIONS, getQueryClient } from '@/constants';
+import { InvitationResponse } from '@/types/response';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
 const InvitePage = async () => {
   const queryClient = getQueryClient();
   await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION('592999830142739431'));
 
-  // const data = queryClient.getQueryData(QUERY_KEYS.INVITATION_PRODUCE('592999830142739431'));
+  const data = queryClient.getQueryData<InvitationResponse>(
+    QUERY_KEYS.INVITATION('592999830142739431'),
+  );
 
-  // console.log(data);
+  if (!data?.result) {
+    return null;
+  }
 
-  return <div>invite Page</div>;
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      {data.result.article.title}
+    </HydrationBoundary>
+  );
 };
 
 export default InvitePage;

--- a/src/app/(Product)/wedding/invite/[id]/page.tsx
+++ b/src/app/(Product)/wedding/invite/[id]/page.tsx
@@ -2,13 +2,13 @@ import { QUERY_KEYS, QUERY_OPTIONS, getQueryClient } from '@/constants';
 import { InvitationResponse } from '@/types/response';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 
-const InvitePage = async () => {
-  const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION('592999830142739431'));
+// 592999830142739431 ID key 값
 
-  const data = queryClient.getQueryData<InvitationResponse>(
-    QUERY_KEYS.INVITATION('592999830142739431'),
-  );
+const InvitePage = async ({ params }: { params: { id: string } }) => {
+  const queryClient = getQueryClient();
+  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION(params.id));
+
+  const data = queryClient.getQueryData<InvitationResponse>(QUERY_KEYS.INVITATION(params.id));
 
   if (!data?.result) {
     return null;

--- a/src/app/(Web)/_components/MainBestSection/MainBestSection.tsx
+++ b/src/app/(Web)/_components/MainBestSection/MainBestSection.tsx
@@ -14,9 +14,11 @@ const MainBestSection = async () => {
   const { theme } = resolveConfig(tailwindConfig);
   const queryClient = getQueryClient();
 
-  await queryClient.prefetchQuery(QUERY_OPTIONS.BEST_INVITATIONS());
+  await queryClient.prefetchQuery(QUERY_OPTIONS.BEST_WEDDING_TEMPLATES());
 
-  const data = queryClient.getQueryData<WeddingTemplatesResponse>(QUERY_KEYS.BEST_INVITATIONS);
+  const data = queryClient.getQueryData<WeddingTemplatesResponse>(
+    QUERY_KEYS.BEST_WEDDING_TEMPLATES,
+  );
 
   if (!data) {
     return null;

--- a/src/app/(Web)/_components/MainBestSection/MainBestSection.tsx
+++ b/src/app/(Web)/_components/MainBestSection/MainBestSection.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import tailwindConfig from '@/../tailwind.config';
 import { ArrowRightIcon } from '@/components/server';
 import { QUERY_KEYS, QUERY_OPTIONS, getQueryClient } from '@/constants';
-import { InvitationTemplatesResponse } from '@/types/response/Invitations';
+import { WeddingTemplatesResponse } from '@/types/response';
 
 import MainSectionTitle from '../MainSectionTitle/MainSectionTitle';
 import { MainBestList } from './_components';
@@ -16,7 +16,7 @@ const MainBestSection = async () => {
 
   await queryClient.prefetchQuery(QUERY_OPTIONS.BEST_INVITATIONS());
 
-  const data = queryClient.getQueryData<InvitationTemplatesResponse>(QUERY_KEYS.BEST_INVITATIONS);
+  const data = queryClient.getQueryData<WeddingTemplatesResponse>(QUERY_KEYS.BEST_INVITATIONS);
 
   if (!data) {
     return null;

--- a/src/app/(Web)/_components/MainBestSection/MainBestSection.tsx
+++ b/src/app/(Web)/_components/MainBestSection/MainBestSection.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import tailwindConfig from '@/../tailwind.config';
 import { ArrowRightIcon } from '@/components/server';
 import { QUERY_KEYS, QUERY_OPTIONS, getQueryClient } from '@/constants';
-import { InvitationsResponse } from '@/types/response/Invitations';
+import { InvitationTemplatesResponse } from '@/types/response/Invitations';
 
 import MainSectionTitle from '../MainSectionTitle/MainSectionTitle';
 import { MainBestList } from './_components';
@@ -16,7 +16,7 @@ const MainBestSection = async () => {
 
   await queryClient.prefetchQuery(QUERY_OPTIONS.BEST_INVITATIONS());
 
-  const data = queryClient.getQueryData<InvitationsResponse>(QUERY_KEYS.BEST_INVITATIONS);
+  const data = queryClient.getQueryData<InvitationTemplatesResponse>(QUERY_KEYS.BEST_INVITATIONS);
 
   if (!data) {
     return null;

--- a/src/app/(Web)/_components/MainBestSection/_components/MainBestList/MainBestList.type.ts
+++ b/src/app/(Web)/_components/MainBestSection/_components/MainBestList/MainBestList.type.ts
@@ -1,7 +1,7 @@
-import { InvitationTemplateItem } from '@/types/response';
+import { WeddingTemplateItem } from '@/types/response';
 
 export interface MainBestListProps {
-  invitation: InvitationTemplateItem[];
+  invitation: WeddingTemplateItem[];
   groom: string;
   bride: string;
   detail: string;

--- a/src/app/(Web)/_components/MainBestSection/_components/MainBestList/MainBestList.type.ts
+++ b/src/app/(Web)/_components/MainBestSection/_components/MainBestList/MainBestList.type.ts
@@ -1,7 +1,7 @@
-import { InvitationItem } from '@/types/response';
+import { InvitationTemplateItem } from '@/types/response';
 
 export interface MainBestListProps {
-  invitation: InvitationItem[];
+  invitation: InvitationTemplateItem[];
   groom: string;
   bride: string;
   detail: string;

--- a/src/app/(Web)/wedding/invitations/@floating/(.)[id]/page.tsx
+++ b/src/app/(Web)/wedding/invitations/@floating/(.)[id]/page.tsx
@@ -12,7 +12,7 @@ interface FloatingProps {
 const Floating = async ({ params }: FloatingProps) => {
   const { id } = params;
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION(id));
+  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(Web)/wedding/invitations/@floating/(.)[id]/page.tsx
+++ b/src/app/(Web)/wedding/invitations/@floating/(.)[id]/page.tsx
@@ -12,7 +12,7 @@ interface FloatingProps {
 const Floating = async ({ params }: FloatingProps) => {
   const { id } = params;
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
+  await queryClient.prefetchQuery(QUERY_OPTIONS.WEDDING_TEMPLATE(id));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(Web)/wedding/invitations/[id]/page.tsx
+++ b/src/app/(Web)/wedding/invitations/[id]/page.tsx
@@ -12,7 +12,7 @@ interface FloatingProps {
 const Floating = async ({ params }: FloatingProps) => {
   const { id } = params;
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION(id));
+  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(Web)/wedding/invitations/[id]/page.tsx
+++ b/src/app/(Web)/wedding/invitations/[id]/page.tsx
@@ -12,7 +12,7 @@ interface FloatingProps {
 const Floating = async ({ params }: FloatingProps) => {
   const { id } = params;
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
+  await queryClient.prefetchQuery(QUERY_OPTIONS.WEDDING_TEMPLATE(id));
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/src/app/(Web)/wedding/invitations/_components/AllInvitations/AllInvitations.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/AllInvitations/AllInvitations.tsx
@@ -4,7 +4,9 @@ import { WeddingTemplatesResponse } from '@/types/response';
 import { InvitationsList } from '..';
 
 const AllInvitations = () => {
-  const data = getQueryClient().getQueryData<WeddingTemplatesResponse>(QUERY_KEYS.ALL_INVITATIONS);
+  const data = getQueryClient().getQueryData<WeddingTemplatesResponse>(
+    QUERY_KEYS.ALL_WEDDING_TEMPLATES,
+  );
 
   if (!data) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/AllInvitations/AllInvitations.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/AllInvitations/AllInvitations.tsx
@@ -1,12 +1,10 @@
 import { QUERY_KEYS, getQueryClient } from '@/constants';
-import { InvitationTemplatesResponse } from '@/types/response';
+import { WeddingTemplatesResponse } from '@/types/response';
 
 import { InvitationsList } from '..';
 
 const AllInvitations = () => {
-  const data = getQueryClient().getQueryData<InvitationTemplatesResponse>(
-    QUERY_KEYS.ALL_INVITATIONS,
-  );
+  const data = getQueryClient().getQueryData<WeddingTemplatesResponse>(QUERY_KEYS.ALL_INVITATIONS);
 
   if (!data) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/AllInvitations/AllInvitations.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/AllInvitations/AllInvitations.tsx
@@ -1,10 +1,12 @@
 import { QUERY_KEYS, getQueryClient } from '@/constants';
-import { InvitationsResponse } from '@/types/response';
+import { InvitationTemplatesResponse } from '@/types/response';
 
 import { InvitationsList } from '..';
 
 const AllInvitations = () => {
-  const data = getQueryClient().getQueryData<InvitationsResponse>(QUERY_KEYS.ALL_INVITATIONS);
+  const data = getQueryClient().getQueryData<InvitationTemplatesResponse>(
+    QUERY_KEYS.ALL_INVITATIONS,
+  );
 
   if (!data) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/BestInvitations/BestInvitations.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/BestInvitations/BestInvitations.tsx
@@ -1,10 +1,12 @@
 import { QUERY_KEYS, getQueryClient } from '@/constants';
-import { InvitationsResponse } from '@/types/response';
+import { InvitationTemplatesResponse } from '@/types/response';
 
 import { InvitationsList } from '..';
 
 const BestInvitations = async () => {
-  const data = getQueryClient().getQueryData<InvitationsResponse>(QUERY_KEYS.BEST_INVITATIONS);
+  const data = getQueryClient().getQueryData<InvitationTemplatesResponse>(
+    QUERY_KEYS.BEST_INVITATIONS,
+  );
 
   if (!data) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/BestInvitations/BestInvitations.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/BestInvitations/BestInvitations.tsx
@@ -1,12 +1,10 @@
 import { QUERY_KEYS, getQueryClient } from '@/constants';
-import { InvitationTemplatesResponse } from '@/types/response';
+import { WeddingTemplatesResponse } from '@/types/response';
 
 import { InvitationsList } from '..';
 
 const BestInvitations = async () => {
-  const data = getQueryClient().getQueryData<InvitationTemplatesResponse>(
-    QUERY_KEYS.BEST_INVITATIONS,
-  );
+  const data = getQueryClient().getQueryData<WeddingTemplatesResponse>(QUERY_KEYS.BEST_INVITATIONS);
 
   if (!data) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/BestInvitations/BestInvitations.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/BestInvitations/BestInvitations.tsx
@@ -4,7 +4,9 @@ import { WeddingTemplatesResponse } from '@/types/response';
 import { InvitationsList } from '..';
 
 const BestInvitations = async () => {
-  const data = getQueryClient().getQueryData<WeddingTemplatesResponse>(QUERY_KEYS.BEST_INVITATIONS);
+  const data = getQueryClient().getQueryData<WeddingTemplatesResponse>(
+    QUERY_KEYS.BEST_WEDDING_TEMPLATES,
+  );
 
   if (!data) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
@@ -7,7 +7,7 @@ import { WeddingTemplates } from '@/components/client';
 import { TemplateLayout } from '@/components/server';
 import { QUERY_OPTIONS } from '@/constants';
 import useClickAway from '@/hooks/useClickAway/useClickAway';
-import { InvitationTemplateResponse } from '@/types/response';
+import { WeddingTemplateResponse } from '@/types/response';
 import { useQuery } from '@tanstack/react-query';
 
 import { InvitationFloatingProps } from './InvitationFloating.type';
@@ -16,7 +16,7 @@ const InvitationFloating = ({ id }: InvitationFloatingProps) => {
   const route = useRouter();
   const ref = useClickAway<HTMLDivElement>(() => route.back());
 
-  const { data } = useQuery<InvitationTemplateResponse>(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
+  const { data } = useQuery<WeddingTemplateResponse>(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
 
   if (!data?.result) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
@@ -7,7 +7,7 @@ import { WeddingTemplates } from '@/components/client';
 import { TemplateLayout } from '@/components/server';
 import { QUERY_OPTIONS } from '@/constants';
 import useClickAway from '@/hooks/useClickAway/useClickAway';
-import { InvitationResponse } from '@/types/response';
+import { InvitationTemplateResponse } from '@/types/response';
 import { useQuery } from '@tanstack/react-query';
 
 import { InvitationFloatingProps } from './InvitationFloating.type';
@@ -16,7 +16,7 @@ const InvitationFloating = ({ id }: InvitationFloatingProps) => {
   const route = useRouter();
   const ref = useClickAway<HTMLDivElement>(() => route.back());
 
-  const { data } = useQuery<InvitationResponse>(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
+  const { data } = useQuery<InvitationTemplateResponse>(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
 
   if (!data?.result) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
@@ -16,7 +16,7 @@ const InvitationFloating = ({ id }: InvitationFloatingProps) => {
   const route = useRouter();
   const ref = useClickAway<HTMLDivElement>(() => route.back());
 
-  const { data } = useQuery<WeddingTemplateResponse>(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
+  const { data } = useQuery<WeddingTemplateResponse>(QUERY_OPTIONS.WEDDING_TEMPLATE(id));
 
   if (!data?.result) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
+++ b/src/app/(Web)/wedding/invitations/_components/InvitationFloating/InvitationFloating.tsx
@@ -16,7 +16,7 @@ const InvitationFloating = ({ id }: InvitationFloatingProps) => {
   const route = useRouter();
   const ref = useClickAway<HTMLDivElement>(() => route.back());
 
-  const { data } = useQuery<InvitationResponse>(QUERY_OPTIONS.INVITATION(id));
+  const { data } = useQuery<InvitationResponse>(QUERY_OPTIONS.INVITATION_TEMPLATE(id));
 
   if (!data?.result) {
     return;

--- a/src/app/(Web)/wedding/invitations/_components/InvitationsList/InvitationsList.type.ts
+++ b/src/app/(Web)/wedding/invitations/_components/InvitationsList/InvitationsList.type.ts
@@ -1,7 +1,7 @@
-import { InvitationTemplateItem } from '@/types/response';
+import { WeddingTemplateItem } from '@/types/response';
 
 export interface InvitationsListProps {
-  productInfoList: InvitationTemplateItem[];
+  productInfoList: WeddingTemplateItem[];
   groom: string;
   bride: string;
   detail: string;

--- a/src/app/(Web)/wedding/invitations/_components/InvitationsList/InvitationsList.type.ts
+++ b/src/app/(Web)/wedding/invitations/_components/InvitationsList/InvitationsList.type.ts
@@ -1,7 +1,7 @@
-import { InvitationItem } from '@/types/response';
+import { InvitationTemplateItem } from '@/types/response';
 
 export interface InvitationsListProps {
-  productInfoList: InvitationItem[];
+  productInfoList: InvitationTemplateItem[];
   groom: string;
   bride: string;
   detail: string;

--- a/src/app/(Web)/wedding/invitations/page.tsx
+++ b/src/app/(Web)/wedding/invitations/page.tsx
@@ -8,8 +8,8 @@ const InvitationsPage = async () => {
   const queryClient = getQueryClient();
 
   await Promise.all([
-    queryClient.prefetchQuery(QUERY_OPTIONS.BEST_INVITATIONS()),
-    queryClient.prefetchQuery(QUERY_OPTIONS.ALL_INVITATIONS()),
+    queryClient.prefetchQuery(QUERY_OPTIONS.BEST_WEDDING_TEMPLATES()),
+    queryClient.prefetchQuery(QUERY_OPTIONS.ALL_WEDDING_TEMPLATES()),
   ]);
 
   return (

--- a/src/constants/Query.ts
+++ b/src/constants/Query.ts
@@ -1,10 +1,10 @@
 import { cache } from 'react';
 
 import {
-  getAllInvitations,
-  getBestInvitations,
+  getAllWeddingTemplates,
+  getBestWeddingTemplates,
   getInvitationProduce,
-  getInvitationTemplate,
+  getWeddingTemplate,
 } from '@/services/server';
 import { QueryClient } from '@tanstack/react-query';
 
@@ -20,19 +20,19 @@ export const QUERY_KEYS = {
 export const QUERY_OPTIONS = {
   BEST_INVITATIONS: () => ({
     queryKey: QUERY_KEYS.BEST_INVITATIONS,
-    queryFn: () => getBestInvitations(),
+    queryFn: () => getBestWeddingTemplates(),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
   ALL_INVITATIONS: () => ({
     queryKey: QUERY_KEYS.ALL_INVITATIONS,
-    queryFn: () => getAllInvitations(),
+    queryFn: () => getAllWeddingTemplates(),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
   INVITATION_TEMPLATE: (templateId: number | string) => ({
     queryKey: QUERY_KEYS.INVITATION_TEMPLATE(templateId),
-    queryFn: () => getInvitationTemplate(templateId),
+    queryFn: () => getWeddingTemplate(templateId),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),

--- a/src/constants/Query.ts
+++ b/src/constants/Query.ts
@@ -3,7 +3,7 @@ import { cache } from 'react';
 import {
   getAllWeddingTemplates,
   getBestWeddingTemplates,
-  getInvitationProduce,
+  getInvitation,
   getWeddingTemplate,
 } from '@/services/server';
 import { QueryClient } from '@tanstack/react-query';
@@ -14,7 +14,7 @@ export const QUERY_KEYS = {
   BEST_INVITATIONS: ['best', 'invitations'],
   ALL_INVITATIONS: ['all', 'invitations'],
   INVITATION_TEMPLATE: (templateId: number | string) => ['invitation', 'template', templateId],
-  INVITATION_PRODUCE: (produceId: number | string) => ['invitation', 'produce', produceId],
+  INVITATION: (produceId: number | string) => ['invitation', 'produce', produceId],
 };
 
 export const QUERY_OPTIONS = {
@@ -36,9 +36,9 @@ export const QUERY_OPTIONS = {
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
-  INVITATION_PRODUCE: (produceId: number | string) => ({
-    queryKey: QUERY_KEYS.INVITATION_PRODUCE(produceId),
-    queryFn: () => getInvitationProduce(produceId),
+  INVITATION: (produceId: number | string) => ({
+    queryKey: QUERY_KEYS.INVITATION(produceId),
+    queryFn: () => getInvitation(produceId),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),

--- a/src/constants/Query.ts
+++ b/src/constants/Query.ts
@@ -11,31 +11,34 @@ import { QueryClient } from '@tanstack/react-query';
 export const getQueryClient = cache(() => new QueryClient());
 
 export const QUERY_KEYS = {
-  BEST_INVITATIONS: ['best', 'invitations'],
-  ALL_INVITATIONS: ['all', 'invitations'],
-  INVITATION_TEMPLATE: (templateId: number | string) => ['invitation', 'template', templateId],
+  BEST_WEDDING_TEMPLATES: ['best', 'invitations'],
+  ALL_WEDDING_TEMPLATES: ['all', 'invitations'],
+  WEDDING_TEMPLATE: (templateId: number | string) => ['invitation', 'template', templateId],
   INVITATION: (produceId: number | string) => ['invitation', 'produce', produceId],
 };
 
 export const QUERY_OPTIONS = {
-  BEST_INVITATIONS: () => ({
-    queryKey: QUERY_KEYS.BEST_INVITATIONS,
+  BEST_WEDDING_TEMPLATES: () => ({
+    queryKey: QUERY_KEYS.BEST_WEDDING_TEMPLATES,
     queryFn: () => getBestWeddingTemplates(),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
-  ALL_INVITATIONS: () => ({
-    queryKey: QUERY_KEYS.ALL_INVITATIONS,
+
+  ALL_WEDDING_TEMPLATES: () => ({
+    queryKey: QUERY_KEYS.ALL_WEDDING_TEMPLATES,
     queryFn: () => getAllWeddingTemplates(),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
-  INVITATION_TEMPLATE: (templateId: number | string) => ({
-    queryKey: QUERY_KEYS.INVITATION_TEMPLATE(templateId),
+
+  WEDDING_TEMPLATE: (templateId: number | string) => ({
+    queryKey: QUERY_KEYS.WEDDING_TEMPLATE(templateId),
     queryFn: () => getWeddingTemplate(templateId),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
+
   INVITATION: (produceId: number | string) => ({
     queryKey: QUERY_KEYS.INVITATION(produceId),
     queryFn: () => getInvitation(produceId),

--- a/src/constants/Query.ts
+++ b/src/constants/Query.ts
@@ -14,7 +14,7 @@ export const getQueryClient = cache(() => new QueryClient());
 export const QUERY_KEYS = {
   BEST_INVITATIONS: ['best', 'invitations'],
   ALL_INVITATIONS: ['all', 'invitations'],
-  INVITATION: (productInfoId: number | string) => ['invitation', productInfoId],
+  INVITATION_TEMPLATE: (productInfoId: number | string) => ['invitation', productInfoId],
 };
 
 export const QUERY_OPTIONS = {
@@ -30,8 +30,8 @@ export const QUERY_OPTIONS = {
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
-  INVITATION: (productInfoId: number | string) => ({
-    queryKey: QUERY_KEYS.INVITATION(productInfoId),
+  INVITATION_TEMPLATE: (productInfoId: number | string) => ({
+    queryKey: QUERY_KEYS.INVITATION_TEMPLATE(productInfoId),
     queryFn: () => getInvitation(productInfoId),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,

--- a/src/constants/Query.ts
+++ b/src/constants/Query.ts
@@ -30,12 +30,13 @@ export const QUERY_OPTIONS = {
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
-  INVITATION_TEMPLATE: (productInfoId: number | string) => ({
-    queryKey: QUERY_KEYS.INVITATION_TEMPLATE(productInfoId),
-    queryFn: () => getInvitation(productInfoId),
+  INVITATION_TEMPLATE: (templateId: number | string) => ({
+    queryKey: QUERY_KEYS.INVITATION_TEMPLATE(templateId),
+    queryFn: () => getInvitation(templateId),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
+  INVITATION_PRODUCE: () => ({}),
 };
 
 export const MUTATE_OPTIONS = {

--- a/src/constants/Query.ts
+++ b/src/constants/Query.ts
@@ -1,11 +1,10 @@
 import { cache } from 'react';
 
-import { Invitation } from '@/app/(Web)/wedding/invitations/produce/[id]/_constants/DefaultValue';
 import {
   getAllInvitations,
   getBestInvitations,
-  getInvitation,
-  postInvitation,
+  getInvitationProduce,
+  getInvitationTemplate,
 } from '@/services/server';
 import { QueryClient } from '@tanstack/react-query';
 
@@ -14,7 +13,8 @@ export const getQueryClient = cache(() => new QueryClient());
 export const QUERY_KEYS = {
   BEST_INVITATIONS: ['best', 'invitations'],
   ALL_INVITATIONS: ['all', 'invitations'],
-  INVITATION_TEMPLATE: (productInfoId: number | string) => ['invitation', productInfoId],
+  INVITATION_TEMPLATE: (templateId: number | string) => ['invitation', 'template', templateId],
+  INVITATION_PRODUCE: (produceId: number | string) => ['invitation', 'produce', produceId],
 };
 
 export const QUERY_OPTIONS = {
@@ -32,16 +32,14 @@ export const QUERY_OPTIONS = {
   }),
   INVITATION_TEMPLATE: (templateId: number | string) => ({
     queryKey: QUERY_KEYS.INVITATION_TEMPLATE(templateId),
-    queryFn: () => getInvitation(templateId),
+    queryFn: () => getInvitationTemplate(templateId),
     gcTime: 1000 * 60 * 60 * 24,
     staleTime: 1000 * 60 * 60 * 24,
   }),
-  INVITATION_PRODUCE: () => ({}),
-};
-
-export const MUTATE_OPTIONS = {
-  INVITATION: () => ({
-    mutationFn: ({ id, invitationInfo }: { id: number; invitationInfo: Invitation }) =>
-      postInvitation({ id, invitationInfo }),
+  INVITATION_PRODUCE: (produceId: number | string) => ({
+    queryKey: QUERY_KEYS.INVITATION_PRODUCE(produceId),
+    queryFn: () => getInvitationProduce(produceId),
+    gcTime: 1000 * 60 * 60 * 24,
+    staleTime: 1000 * 60 * 60 * 24,
   }),
 };

--- a/src/dump/InvitationTemplate/InvitationTemplate.type.ts
+++ b/src/dump/InvitationTemplate/InvitationTemplate.type.ts
@@ -1,11 +1,8 @@
-import { InvitationTemplateItem, InvitationTemplateResponse } from '@/types/response';
+import { WeddingTemplateItem, WeddingTemplateResponse } from '@/types/response';
 
 export interface InvitationTemplateProps
-  extends Pick<
-    InvitationTemplateResponse['result'],
-    'title' | 'details' | 'groomName' | 'brideName'
-  > {
-  productInfo: Pick<InvitationTemplateItem, 'id' | 'imageUrl' | 'templateName'>;
+  extends Pick<WeddingTemplateResponse['result'], 'title' | 'details' | 'groomName' | 'brideName'> {
+  productInfo: Pick<WeddingTemplateItem, 'id' | 'imageUrl' | 'templateName'>;
   width: number;
   height: number;
 }

--- a/src/dump/InvitationTemplate/InvitationTemplate.type.ts
+++ b/src/dump/InvitationTemplate/InvitationTemplate.type.ts
@@ -1,8 +1,11 @@
-import { InvitationItem, InvitationResponse } from '@/types/response';
+import { InvitationTemplateItem, InvitationTemplateResponse } from '@/types/response';
 
 export interface InvitationTemplateProps
-  extends Pick<InvitationResponse['result'], 'title' | 'details' | 'groomName' | 'brideName'> {
-  productInfo: Pick<InvitationItem, 'id' | 'imageUrl' | 'templateName'>;
+  extends Pick<
+    InvitationTemplateResponse['result'],
+    'title' | 'details' | 'groomName' | 'brideName'
+  > {
+  productInfo: Pick<InvitationTemplateItem, 'id' | 'imageUrl' | 'templateName'>;
   width: number;
   height: number;
 }

--- a/src/services/server/index.ts
+++ b/src/services/server/index.ts
@@ -1,1 +1,1 @@
-export * from './invitations/invitations';
+export * from './weddingTemplates/weddingTemplates';

--- a/src/services/server/index.ts
+++ b/src/services/server/index.ts
@@ -1,1 +1,2 @@
 export * from './weddingTemplates/weddingTemplates';
+export * from './invitations/invitations';

--- a/src/services/server/invitations/invitations.ts
+++ b/src/services/server/invitations/invitations.ts
@@ -1,0 +1,13 @@
+import { fetchApi } from '@/api';
+
+export const getInvitation = async (produceId: number | string) => {
+  const response = await fetchApi(`/product/invitation/read/${produceId}`, {
+    next: { revalidate: 1000 * 60 * 60 * 24 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+};

--- a/src/services/server/invitations/invitations.ts
+++ b/src/services/server/invitations/invitations.ts
@@ -25,8 +25,20 @@ export const getAllInvitations = async () => {
   return response.json();
 };
 
-export const getInvitation = async (productInfoId: number | string) => {
-  const response = await fetchApi(`/api/product/info/${productInfoId}`, {
+export const getInvitationTemplate = async (templateId: number | string) => {
+  const response = await fetchApi(`/api/product/info/${templateId}`, {
+    next: { revalidate: 1000 * 60 * 60 * 24 },
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+
+  return response.json();
+};
+
+export const getInvitationProduce = async (produceId: number | string) => {
+  const response = await fetchApi(`${produceId}`, {
     next: { revalidate: 1000 * 60 * 60 * 24 },
   });
 

--- a/src/services/server/weddingTemplates/weddingTemplates.ts
+++ b/src/services/server/weddingTemplates/weddingTemplates.ts
@@ -1,7 +1,7 @@
 import { fetchApi } from '@/api';
 import { Invitation } from '@/app/(Web)/wedding/invitations/produce/[id]/_constants/DefaultValue';
 
-export const getBestInvitations = async () => {
+export const getBestWeddingTemplates = async () => {
   const response = await fetchApi('/api/product/info/best', {
     next: { revalidate: 1000 * 60 * 60 * 24 },
   });
@@ -13,7 +13,7 @@ export const getBestInvitations = async () => {
   return response.json();
 };
 
-export const getAllInvitations = async () => {
+export const getAllWeddingTemplates = async () => {
   const response = await fetchApi('/api/product/info', {
     next: { revalidate: 1000 * 60 * 60 * 24 },
   });
@@ -25,7 +25,7 @@ export const getAllInvitations = async () => {
   return response.json();
 };
 
-export const getInvitationTemplate = async (templateId: number | string) => {
+export const getWeddingTemplate = async (templateId: number | string) => {
   const response = await fetchApi(`/api/product/info/${templateId}`, {
     next: { revalidate: 1000 * 60 * 60 * 24 },
   });
@@ -38,7 +38,7 @@ export const getInvitationTemplate = async (templateId: number | string) => {
 };
 
 export const getInvitationProduce = async (produceId: number | string) => {
-  const response = await fetchApi(`${produceId}`, {
+  const response = await fetchApi(`/product/invitation/read/${produceId}`, {
     next: { revalidate: 1000 * 60 * 60 * 24 },
   });
 

--- a/src/types/response/Invitation.ts
+++ b/src/types/response/Invitation.ts
@@ -1,0 +1,165 @@
+/** Cover */
+
+export interface InvitationCover {
+  priority: number;
+  imageUrl: string;
+  imageOriginName: string;
+  imageStoreFileName: string;
+  weddingDate: string;
+  detail: string;
+  groomName: string;
+  brideName: string;
+  coverContents: string;
+}
+
+/** WeddingPlace */
+
+export interface InvitationWeddingPlace {
+  priority: number;
+  placeName: string;
+  detail: string;
+  placeAddress: string;
+  latitude: number;
+  longitude: number;
+}
+
+/** Article */
+
+export interface InvitationArticleItem {
+  name: string;
+  fatherName: string;
+  isFatherCondolences: boolean;
+  motherName: string;
+  isMotherCondolences: boolean;
+  relation: string;
+}
+
+export interface InvitationArticle {
+  priority: number;
+  title: string;
+  contents: string;
+  groomInfo: InvitationArticleItem;
+  brideInfo: InvitationArticleItem;
+}
+
+/** Contact */
+
+export interface InvitationContactItem {
+  name: string;
+  phoneNumber: string;
+  relation: string;
+}
+
+export interface InvitationContact {
+  priority: number;
+  groomContactInfo: InvitationContactItem[];
+  brideContactInfo: InvitationContactItem[];
+}
+
+/** Transport */
+
+export interface InvitationTransportItem {
+  kind: string;
+  detail: string;
+}
+
+export interface InvitationTransport {
+  priority: number;
+  transport: InvitationTransportItem[];
+}
+
+/** Account */
+
+export interface InvitationAccountItem {
+  name: string;
+  bankName: string;
+  accountNumber: string;
+}
+
+export interface InvitationAccount {
+  priority: number;
+  groomAccountInfo: InvitationAccountItem[];
+  brideAccountInfo: InvitationAccountItem[];
+}
+
+/** Gallery */
+
+export interface InvitationGalleryItem {
+  priority: number;
+  originFileName: string;
+  imageUrl: string;
+}
+
+export interface InvitationGallery {
+  priority: number;
+  galleries: InvitationGalleryItem[];
+}
+
+export interface InvitationResponse {
+  status: number;
+  message: string;
+  result: {
+    tsid: number;
+    isPaid: boolean;
+
+    cover: InvitationCover;
+    weddingPlace: InvitationWeddingPlace;
+
+    weddingDate: {
+      priority: number;
+      date: string;
+      dateType: string;
+    };
+
+    article: InvitationArticle;
+
+    contact: InvitationContact;
+    transport: InvitationTransport;
+
+    // guestbook: {
+    //   priority: number;
+    //   guestbookList: {
+    //     content: [
+    //       {
+    //         name: string;
+    //         message: string;
+    //       },
+    //     ];
+    //     pageable: {
+    //       pageNumber: number;
+    //       pageSize: number;
+    //       sort: {
+    //         empty: boolean;
+    //         unsorted: boolean;
+    //         sorted: boolean;
+    //       };
+    //       offset: number;
+    //       paged: boolean;
+    //       unpaged: boolean;
+    //     };
+    //     totalPages: number;
+    //     totalElements: number;
+    //     last: boolean;
+    //     size: number;
+    //     number: number;
+    //     sort: {
+    //       empty: boolean;
+    //       unsorted: boolean;
+    //       sorted: boolean;
+    //     };
+    //     numberOfElements: number;
+    //     first: boolean;
+    //     empty: boolean;
+    //   };
+    // };
+
+    account: InvitationAccount;
+    gallery: InvitationGallery;
+
+    shareThumbnail: {
+      shareTitle: string;
+      shareContents: string;
+      imageUrl: string;
+    };
+  };
+}

--- a/src/types/response/Invitations.ts
+++ b/src/types/response/Invitations.ts
@@ -1,4 +1,4 @@
-export interface InvitationsResponse {
+export interface InvitationTemplatesResponse {
   status: number;
   message: string;
   result: {
@@ -6,11 +6,11 @@ export interface InvitationsResponse {
     details: string;
     groomName: string;
     brideName: string;
-    productInfoList: InvitationItem[];
+    productInfoList: InvitationTemplateItem[];
   };
 }
 
-export interface InvitationResponse {
+export interface InvitationTemplateResponse {
   status: number;
   message: string;
   result: {
@@ -18,11 +18,11 @@ export interface InvitationResponse {
     details: string;
     groomName: string;
     brideName: string;
-    productInfo: InvitationItem;
+    productInfo: InvitationTemplateItem;
   };
 }
 
-export interface InvitationItem {
+export interface InvitationTemplateItem {
   id: number;
   imageUrl: string;
   templateName: string;

--- a/src/types/response/WeddingTemplates.ts
+++ b/src/types/response/WeddingTemplates.ts
@@ -1,4 +1,4 @@
-export interface InvitationTemplatesResponse {
+export interface WeddingTemplatesResponse {
   status: number;
   message: string;
   result: {
@@ -6,11 +6,11 @@ export interface InvitationTemplatesResponse {
     details: string;
     groomName: string;
     brideName: string;
-    productInfoList: InvitationTemplateItem[];
+    productInfoList: WeddingTemplateItem[];
   };
 }
 
-export interface InvitationTemplateResponse {
+export interface WeddingTemplateResponse {
   status: number;
   message: string;
   result: {
@@ -18,11 +18,11 @@ export interface InvitationTemplateResponse {
     details: string;
     groomName: string;
     brideName: string;
-    productInfo: InvitationTemplateItem;
+    productInfo: WeddingTemplateItem;
   };
 }
 
-export interface InvitationTemplateItem {
+export interface WeddingTemplateItem {
   id: number;
   imageUrl: string;
   templateName: string;

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -1,1 +1,2 @@
 export * from './WeddingTemplates';
+export * from './Invitation';

--- a/src/types/response/index.ts
+++ b/src/types/response/index.ts
@@ -1,1 +1,1 @@
-export * from './Invitations';
+export * from './WeddingTemplates';


### PR DESCRIPTION
## 📝 설명

- #133 
close #133 

## ✅ PR 유형

- [x] 새로운 기능 추가
- [x] 코드 리팩토링
- [x] 파일 혹은 폴더명 수정 / 삭제

## 💻 작업 내용

- produce route에 `INVITE GET API` 연결

현재는 page.tsx에 API를 호출하고 hydrate 전달

- 수정

**기존 모든 invitations를 Wedding Template 로 네이밍 변경**




## 💬 PR 포인트

<!-- PR 리뷰 시 공유 사항 또는 유심히 보면 좋을 부분을 설명합니다. -->
